### PR TITLE
Fix per-player deck pools across shuffles

### DIFF
--- a/app/admin/decks/page.tsx
+++ b/app/admin/decks/page.tsx
@@ -11,6 +11,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Trash2, Edit, Plus, Download, Home } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import Link from "next/link"
+import { COLOR_OPTIONS, BRACKET_OPTIONS, ADMIN_SECRET } from "@/lib/constants"
 
 interface Deck {
   id: string
@@ -21,10 +22,6 @@ interface Deck {
   deckList?: string
   createdAt: string
 }
-
-const ADMIN_SECRET = "deck-master-2024"
-const COLOR_OPTIONS = ["White", "Blue", "Black", "Red", "Green", "Colorless"]
-const BRACKET_OPTIONS = [1, 2, 3, 4, 5]
 
 export default function AdminDecks() {
   const searchParams = useSearchParams()

--- a/app/api/assign/route.ts
+++ b/app/api/assign/route.ts
@@ -1,6 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { shuffle } from "lodash";
+import { colorsMatch, filterDecks, DeckPreferences } from "@/lib/utils";
 
 export async function POST(request: NextRequest) {
   try {
@@ -22,74 +23,26 @@ export async function POST(request: NextRequest) {
     const usedDeckIds = new Set(usedDecks.map((ud) => ud.deckId));
 
     // Filter out used decks (only finalized ones)
-    const unusedDecks = availableDecks.filter(
-      (deck) => !usedDeckIds.has(deck.id)
-    );
+  let remainingDecks = availableDecks.filter((deck) => !usedDeckIds.has(deck.id));
 
-    // Assignment logic - try to match each player's individual preferences
     const assignment: { [key: string]: any } = {};
-    const assignedDecks = new Set<string>();
+    const pools: { [key: string]: any[] } = {};
 
     for (const player of players) {
-      const prefs = playerPreferences[player];
+      const prefs: DeckPreferences = playerPreferences[player];
 
-      // Start with all unused decks not yet assigned in this session
-      let playerDecks = unusedDecks.filter(
-        (deck) => !assignedDecks.has(deck.id)
-      );
+      const playerPool = filterDecks(remainingDecks, prefs);
 
-      // Apply player's color preferences (EXCLUSIVE matching)
-      if (prefs && prefs.colors.length > 0) {
-        const colorFilteredDecks = playerDecks.filter((deck) => {
-          const deckColors = JSON.parse(deck.colors);
-
-          // Check if deck colors exactly match the preferred colors
-          // Sort both arrays to compare them properly
-          const sortedDeckColors = [...deckColors].sort();
-          const sortedPrefColors = [...prefs.colors].sort();
-
-          console.log("sortedDeckColors = " + sortedDeckColors);
-          console.log("sortedPrefColors = " + sortedPrefColors);
-
-          return (
-            sortedDeckColors.length === sortedPrefColors.length &&
-            sortedDeckColors.every(
-              (color, index) => color === sortedPrefColors[index]
-            )
-          );
-        });
-
-        // Use color-filtered decks if available, otherwise fall back to all decks
-        if (colorFilteredDecks.length > 0) {
-          playerDecks = colorFilteredDecks;
-        }
-      }
-
-      // Apply player's commander preference
-      if (prefs && prefs.commander && prefs.commander !== "Any commander") {
-        const commanderFilteredDecks = playerDecks.filter((deck) =>
-          deck.commander.toLowerCase().includes(prefs.commander.toLowerCase())
-        );
-
-        // Use commander-filtered decks if available, otherwise fall back to color/all decks
-        if (commanderFilteredDecks.length > 0) {
-          playerDecks = commanderFilteredDecks;
-        }
-      }
-
-      // If no decks available for this player, return error
-      if (playerDecks.length === 0) {
+      if (playerPool.length === 0) {
         return NextResponse.json(
           {
             error: `No available decks for ${player} with their preferences. Try adjusting preferences or resetting history.`,
           },
-          { status: 400 }
+          { status: 400 },
         );
       }
 
-      // Randomly select a deck for this player
-      const selectedDeck = shuffle(playerDecks)[0];
-      assignedDecks.add(selectedDeck.id);
+      const selectedDeck = shuffle(playerPool)[0];
 
       assignment[player] = {
         deck: {
@@ -97,10 +50,16 @@ export async function POST(request: NextRequest) {
           colors: JSON.parse(selectedDeck.colors),
         },
       };
+
+      pools[player] = playerPool
+        .filter((d) => d.id !== selectedDeck.id)
+        .map((d) => ({ ...d, colors: JSON.parse(d.colors) }));
+
+      remainingDecks = remainingDecks.filter((d) => d.id !== selectedDeck.id);
     }
 
     // NOTE: We don't mark decks as used here - only when finalized
-    return NextResponse.json({ assignment });
+    return NextResponse.json({ assignment, pools });
   } catch (error) {
     console.error("Assignment failed:", error);
     return NextResponse.json({ error: "Assignment failed" }, { status: 500 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,8 +10,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Shuffle, History, Settings, Lock } from "lucide-react"
-
-const ADMIN_PASSWORD = "deck-master-2024"
+import { ADMIN_SECRET } from "@/lib/constants"
 
 export default function HomePage() {
   const [password, setPassword] = useState("")
@@ -21,9 +20,9 @@ export default function HomePage() {
   const handlePasswordSubmit = (e: React.FormEvent) => {
     e.preventDefault()
 
-    if (password === ADMIN_PASSWORD) {
+    if (password === ADMIN_SECRET) {
       alert("Access granted! Redirecting to admin panel...")
-      router.push(`/admin/decks?admin=${ADMIN_PASSWORD}`)
+      router.push(`/admin/decks?admin=${ADMIN_SECRET}`)
     } else {
       alert("Incorrect password. Please try again.")
       setPassword("")

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,12 @@
+export const COLOR_OPTIONS = [
+  "White",
+  "Blue",
+  "Black",
+  "Red",
+  "Green",
+  "Colorless",
+];
+
+export const BRACKET_OPTIONS = [1, 2, 3, 4, 5];
+
+export const ADMIN_SECRET = "deck-master-2024";

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,38 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function colorsMatch(
+  deckColors: string[],
+  prefColors: string[],
+): boolean {
+  const sortedDeck = [...deckColors].sort()
+  const sortedPref = [...prefColors].sort()
+  return (
+    sortedDeck.length === sortedPref.length &&
+    sortedDeck.every((color, idx) => color === sortedPref[idx])
+  )
+}
+
+export interface DeckPreferences {
+  colors: string[]
+  commander?: string
+}
+
+export function filterDecks<T extends { colors: string; commander: string }>(
+  decks: T[],
+  prefs: DeckPreferences,
+): T[] {
+  let filtered = [...decks]
+  if (prefs.colors.length > 0) {
+    filtered = filtered.filter((d) =>
+      colorsMatch(JSON.parse(d.colors), prefs.colors),
+    )
+  }
+  if (prefs.commander && prefs.commander !== 'Any commander') {
+    filtered = filtered.filter((d) =>
+      d.commander.toLowerCase().includes(prefs.commander!.toLowerCase()),
+    )
+  }
+  return filtered
+}


### PR DESCRIPTION
## Summary
- add `filterDecks` helper to centralise colour and commander filtering
- return remaining deck pools from assignment and shuffle APIs
- track deck pools on the client and remove the chosen deck after every shuffle
- disable assign button when any player has no available decks

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68887828c488832fb05549e1af31c8ff